### PR TITLE
Stop running pylint in RUN.bat

### DIFF
--- a/RUN.bat
+++ b/RUN.bat
@@ -4,11 +4,11 @@ cd /d "%~dp0"
 setlocal enableextensions enabledelayedexpansion
 
 
-:: Run style checks and unit tests
-echo Running lint and tests...
-python run_checks.py
+:: Run unit tests only
+echo Running tests...
+python -m pytest -q test.py
 if errorlevel 1 (
-    echo [ABORTED] Lint or tests failed. Aborting.
+    echo [ABORTED] Tests failed. Aborting.
     pause
     exit /b 1
 )


### PR DESCRIPTION
## Summary
- remove automatic pylint execution from `RUN.bat`
- run only unit tests before launching the scanner

## Testing
- `pytest -q test.py`


------
https://chatgpt.com/codex/tasks/task_e_6842f75aeb3083218dbb571d8d9059ba