### PR TITLE
Fix open interest weekly/monthly data

### DIFF
--- a/core.py
+++ b/core.py
@@ -253,22 +253,24 @@ def process_symbol_correlation(symbol: str, btc_klines: list, logger: logging.Lo
 
 
 OPEN_INTEREST_INTERVALS = {
-    "5M": "5min",
-    "15M": "15min",
-    "30M": "30min",
-    "1H": "1h",
-    "4H": "4h",
-    "1D": "1d",
-    "1W": "1w",
-    "1M": "1M",
+    "5M": ("5min", 2),
+    "15M": ("15min", 2),
+    "30M": ("30min", 2),
+    "1H": ("1h", 2),
+    "4H": ("4h", 2),
+    "1D": ("1d", 2),
+    # 1 week and 1 month data are not provided directly by the API
+    # so use daily data and request enough rows to cover the period.
+    "1W": ("1d", 7),
+    "1M": ("1d", 30),
 }
 
 
 def get_open_interest_changes(symbol: str) -> dict:
     """Return open interest % change for multiple intervals."""
     result: dict[str, float] = {}
-    for name, interval in OPEN_INTEREST_INTERVALS.items():
-        result[name] = round(get_open_interest_change(symbol, interval, 2), 4)
+    for name, (interval, limit) in OPEN_INTEREST_INTERVALS.items():
+        result[name] = round(get_open_interest_change(symbol, interval, limit), 4)
     return result
 
 

--- a/test.py
+++ b/test.py
@@ -121,6 +121,16 @@ def test_process_symbol_open_interest_with_mocked_logger():
         assert set(result.keys()) == expected_keys
 
 
+def test_get_open_interest_changes_calls_expected_params():
+    """Verify week and month calculations use daily data."""
+    with patch("core.get_open_interest_change", return_value=5.0) as mock_oi:
+        result = core.get_open_interest_changes("BTCUSDT")
+        assert set(result) == {"5M", "15M", "30M", "1H", "4H", "1D", "1W", "1M"}
+        assert mock_oi.call_count == 8
+        mock_oi.assert_any_call("BTCUSDT", "1d", 7)
+        mock_oi.assert_any_call("BTCUSDT", "1d", 30)
+
+
 def test_process_symbol_funding_with_mocked_logger():
     """Ensure funding rate metric returns correct mapping."""
     with patch("core.get_funding_rate", return_value=(0.001, 0)):


### PR DESCRIPTION
## Summary
- handle weekly and monthly open interest data via daily intervals
- verify daily interval usage for 1W and 1M with new unit test

## Testing
- `python run_checks.py`

------
https://chatgpt.com/codex/tasks/task_e_68432815980c83219ddad07830a31fe4