### PR TITLE
Add continuous scan script with timestamped Excel export

### DIFF
--- a/continuous_scan.py
+++ b/continuous_scan.py
@@ -1,0 +1,53 @@
+"""Run Bybit scans at a fixed interval and save each result."""
+
+import time
+from datetime import datetime
+
+import scan
+import core
+
+
+def run_periodic_scans(interval_minutes: int = 30) -> None:
+    """Run a volume scan every ``interval_minutes`` minutes."""
+    logger = scan.setup_logging()
+    while True:
+        logger.info("Starting periodic scan")
+        try:
+            logger.info("Fetching USDT perpetual futures from Bybit...")
+            all_symbols = core.get_tradeable_symbols_sorted_by_volume()
+            logger.info("Total pairs found: %d", len(all_symbols))
+
+            if not all_symbols:
+                logger.warning("No symbols retrieved. Skipping export.")
+                time.sleep(interval_minutes * 60)
+                continue
+
+            volume_df, funding_df, oi_df, symbol_order = scan.run_scan(all_symbols, logger)
+            corr_df = scan.run_correlation_scan(all_symbols, logger)
+            vol_df = scan.run_volatility_scan(all_symbols, logger)
+
+            timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+            filename = f"Scan_{timestamp}.xlsx"
+            scan.export_all_data(
+                volume_df,
+                funding_df,
+                oi_df,
+                corr_df,
+                vol_df,
+                symbol_order,
+                logger,
+                filename=filename,
+            )
+            scan.send_push_notification(
+                "Scan complete",
+                f"{filename} has been exported.",
+                logger,
+            )
+        except (RuntimeError, ValueError, TypeError) as exc:
+            logger.exception("Script failed: %s", exc)
+        logger.info("Waiting %d minutes for next scan...", interval_minutes)
+        time.sleep(interval_minutes * 60)
+
+
+if __name__ == "__main__":
+    run_periodic_scans()

--- a/run_checks.py
+++ b/run_checks.py
@@ -14,6 +14,7 @@ LOG_DIR = core.LOG_DIR
 PY_FILES = [
     "core.py",
     "scan.py",
+    "continuous_scan.py",
     "test.py",
     "volume_math.py",
     "correlation_math.py",

--- a/scan.py
+++ b/scan.py
@@ -335,11 +335,12 @@ def export_all_data(  # pylint: disable=too-many-arguments,too-many-positional-a
     vol_df: pd.DataFrame,
     symbol_order: list[str],
     logger: logging.Logger,
+    filename: str = "Scan.xlsx",
 ) -> None:
-    """Write all metric DataFrames to ``Scan.xlsx``."""
+    """Write all metric DataFrames to an Excel file."""
 
-    wait_for_file_close("Scan.xlsx", logger)
-    with pd.ExcelWriter("Scan.xlsx", engine="xlsxwriter") as writer:
+    wait_for_file_close(filename, logger)
+    with pd.ExcelWriter(filename, engine="xlsxwriter") as writer:
         export_to_excel(
             volume_df,
             symbol_order,
@@ -381,7 +382,7 @@ def export_all_data(  # pylint: disable=too-many-arguments,too-many-positional-a
             sheet_name="Price Movement",
             apply_conditional_formatting=False,
         )
-    logger.info("Export complete: Scan.xlsx")
+    logger.info("Export complete: %s", filename)
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- allow `export_all_data` to write to a custom filename
- run pylint on new script in `run_checks.py`
- implement `continuous_scan.py` to repeatedly run the scan every 30 minutes and save results with a timestamped Excel file

## Testing
- `python run_checks.py`

------
https://chatgpt.com/codex/tasks/task_e_684a78a1bce08321a3ab4868a994d96f