### PR TITLE
Improve periodic scan log messages

### DIFF
--- a/continuous_scan.py
+++ b/continuous_scan.py
@@ -10,6 +10,7 @@ import core
 def run_periodic_scans(interval_minutes: int = 30) -> None:
     """Run a volume scan every ``interval_minutes`` minutes."""
     logger = scan.setup_logging()
+    logger.info("Continuous scan started. Press Ctrl+C to stop.")
     while True:
         logger.info("Starting periodic scan")
         try:
@@ -19,6 +20,9 @@ def run_periodic_scans(interval_minutes: int = 30) -> None:
 
             if not all_symbols:
                 logger.warning("No symbols retrieved. Skipping export.")
+                logger.info(
+                    "Waiting %d minutes for next scan...", interval_minutes
+                )
                 time.sleep(interval_minutes * 60)
                 continue
 


### PR DESCRIPTION
## Summary
- add a startup message in `continuous_scan.py`
- log wait time when no symbols are found

## Testing
- `python run_checks.py`

------
https://chatgpt.com/codex/tasks/task_e_684a7fcef3148321986fc299e9423e57