### PR TITLE
Remove merged cells in Excel export

### DIFF
--- a/scan.py
+++ b/scan.py
@@ -118,11 +118,7 @@ def export_to_excel(
     df.to_excel(writer, index=False, sheet_name=sheet_name, startrow=1)
     worksheet = writer.sheets[sheet_name]
     header_format = writer.book.add_format({"bold": True})
-    end_col = chr(ord("A") + len(df.columns) - 1)
-    if len(df.columns) > 2:
-        worksheet.merge_range(f"B1:{end_col}1", header, header_format)
-    else:
-        worksheet.write("B1", header, header_format)
+    worksheet.write("B1", header, header_format)
     worksheet.freeze_panes(2, 0)
 
     red_format = writer.book.add_format({

--- a/test.py
+++ b/test.py
@@ -341,10 +341,10 @@ def test_export_to_excel_skips_conditional_formatting():
         worksheet.conditional_format.assert_not_called()
 
 
-def test_export_to_excel_writes_header_without_merge():
-    """Header is written directly when only one metric column exists."""
+def test_export_to_excel_does_not_merge_cells():
+    """Header is written directly and no cells are merged."""
     df = pd.DataFrame([
-        {"Symbol": "BTCUSDT", "5M": 1.0}
+        {"Symbol": "BTCUSDT", "5M": 1.0, "15M": 0.5}
     ])
     logger = MagicMock()
     with patch("scan.pd.ExcelWriter") as mock_writer, \


### PR DESCRIPTION
## Summary
- stop merging header cells when exporting DataFrames
- update test to ensure no merge occurs

## Testing
- `python run_checks.py`

------
https://chatgpt.com/codex/tasks/task_e_684abb92def48321841da8f9ef88f7e0