### PR TITLE
Move header cell to A1

### DIFF
--- a/scan.py
+++ b/scan.py
@@ -118,7 +118,7 @@ def export_to_excel(
     df.to_excel(writer, index=False, sheet_name=sheet_name, startrow=1)
     worksheet = writer.sheets[sheet_name]
     header_format = writer.book.add_format({"bold": True})
-    worksheet.write("B1", header, header_format)
+    worksheet.write("A1", header, header_format)
     worksheet.freeze_panes(2, 0)
 
     red_format = writer.book.add_format({

--- a/test.py
+++ b/test.py
@@ -360,4 +360,4 @@ def test_export_to_excel_does_not_merge_cells():
         scan.export_to_excel(df, ["BTCUSDT"], logger,
                              filename="x.xlsx", header="hdr")
         worksheet.merge_range.assert_not_called()
-        worksheet.write.assert_any_call("B1", "hdr", fmt)
+        worksheet.write.assert_any_call("A1", "hdr", fmt)


### PR DESCRIPTION
## Summary
- write header to A1 instead of B1 when exporting to Excel
- update tests for new header location

## Testing
- `python run_checks.py`

------
https://chatgpt.com/codex/tasks/task_e_684d594d6364832182730974785258d6