### PR TITLE
Add price change metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Results are written to multiple spreadsheets:
 * ``Crypto_Volume.xlsx`` containing volume change statistics
 * ``Funding_Rates.xlsx`` with the latest funding rate for each pair
 * ``Open_Interest.xlsx`` showing percent changes in open interest across several timeframes, now including 1 day, 1 week and 1 month intervals
+* ``Price_Change.xlsx`` listing the percentage price change over common intraday periods
 
 The funding and open interest sheets omit the ``24h USD Volume`` column, but rows remain sorted using this metric.
 

--- a/continuous_scan.py
+++ b/continuous_scan.py
@@ -29,6 +29,7 @@ def run_periodic_scans(interval_minutes: int = 30) -> None:
             volume_df, funding_df, oi_df, symbol_order = scan.run_scan(all_symbols, logger)
             corr_df = scan.run_correlation_scan(all_symbols, logger)
             vol_df = scan.run_volatility_scan(all_symbols, logger)
+            price_df = scan.run_price_change_scan(all_symbols, logger)
 
             timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
             filename = f"Scan_{timestamp}.xlsx"
@@ -38,6 +39,7 @@ def run_periodic_scans(interval_minutes: int = 30) -> None:
                 oi_df,
                 corr_df,
                 vol_df,
+                price_df,
                 symbol_order,
                 logger,
                 filename=filename,

--- a/core.py
+++ b/core.py
@@ -13,6 +13,7 @@ from tqdm import tqdm
 from volume_math import calculate_volume_change
 import correlation_math
 import volatility_math
+import price_change_math
 
 MAX_DUPLICATE_RETRIES = 3
 
@@ -300,4 +301,20 @@ def process_symbol_volatility(symbol: str, logger: logging.Logger) -> dict:
         "30M": round(volatility_math.calculate_price_range_percent(klines, 30), 4),
         "1H": round(volatility_math.calculate_price_range_percent(klines, 60), 4),
         "4H": round(volatility_math.calculate_price_range_percent(klines, 240), 4),
+    }
+
+
+def process_symbol_price_change(symbol: str, logger: logging.Logger) -> dict:
+    """Return close price change metrics for ``symbol``."""
+    klines = fetch_recent_klines(symbol)
+    if not klines:
+        logger.warning("%s skipped: No valid klines returned for price change.", symbol)
+        return None
+    return {
+        "Symbol": symbol,
+        "5M": round(price_change_math.calculate_price_change_percent(klines, 5), 4),
+        "15M": round(price_change_math.calculate_price_change_percent(klines, 15), 4),
+        "30M": round(price_change_math.calculate_price_change_percent(klines, 30), 4),
+        "1H": round(price_change_math.calculate_price_change_percent(klines, 60), 4),
+        "4H": round(price_change_math.calculate_price_change_percent(klines, 240), 4),
     }

--- a/price_change_math.py
+++ b/price_change_math.py
@@ -1,0 +1,19 @@
+"""Compute percentage price change for a block of klines."""
+
+from __future__ import annotations
+
+
+def calculate_price_change_percent(klines: list, block_size: int) -> float:
+    """Return the close-to-close percentage change over ``block_size`` minutes."""
+    try:
+        sorted_klines = sorted(klines, key=lambda k: int(k[0]))
+        if len(sorted_klines) < block_size + 1:
+            return 0.0
+        subset = sorted_klines[-(block_size + 1):]
+        start = float(subset[0][4])
+        end = float(subset[-1][4])
+        if start == 0:
+            return 0.0
+        return (end - start) / start * 100
+    except (ValueError, IndexError, TypeError):
+        return 0.0

--- a/run_checks.py
+++ b/run_checks.py
@@ -19,6 +19,7 @@ PY_FILES = [
     "volume_math.py",
     "correlation_math.py",
     "volatility_math.py",
+    "price_change_math.py",
 ]
 
 

--- a/test.py
+++ b/test.py
@@ -13,6 +13,7 @@ import scan
 from volume_math import calculate_volume_change
 import correlation_math
 import volatility_math
+import price_change_math
 
 def test_get_tradeable_symbols_sorted_by_volume():
     """Test symbol sorting by 24h volume descending order."""
@@ -316,6 +317,25 @@ def test_process_symbol_volatility_with_mocked_logger():
     mock_klines = [[str(i), "1", "10", "8", "", "1"] for i in range(5040)]
     with patch("core.fetch_recent_klines", return_value=mock_klines):
         result = core.process_symbol_volatility("BTCUSDT", MagicMock())
+        expected_keys = {"Symbol", "5M", "15M", "30M", "1H", "4H"}
+        assert set(result.keys()) == expected_keys
+
+
+def test_calculate_price_change_percent():
+    """Calculate close-to-close change for latest block."""
+    klines = [
+        [str(i), "", "", "", str(i + 1), "1"]
+        for i in range(5)
+    ] + [["5", "", "", "", "2", "1"]]
+    result = price_change_math.calculate_price_change_percent(klines, 5)
+    assert round(result, 2) == 100.0
+
+
+def test_process_symbol_price_change_with_mocked_logger():
+    """Ensure price change metrics include expected keys."""
+    mock_klines = [[str(i), "", "", "", str(i), "1"] for i in range(5040)]
+    with patch("core.fetch_recent_klines", return_value=mock_klines):
+        result = core.process_symbol_price_change("BTCUSDT", MagicMock())
         expected_keys = {"Symbol", "5M", "15M", "30M", "1H", "4H"}
         assert set(result.keys()) == expected_keys
 


### PR DESCRIPTION
## Summary
- add new `price_change_math` module
- calculate price change for each symbol
- export price change sheet to Excel
- run price change scan in continuous and single scans
- update tests and linter config
- document new spreadsheet

## Testing
- `python run_checks.py`

------
https://chatgpt.com/codex/tasks/task_e_684e917245488321bf6f8aa5aeaebbfc