### PR TITLE
Fix 4H percentile calculation

### DIFF
--- a/core.py
+++ b/core.py
@@ -125,7 +125,7 @@ def fetch_with_backoff(url: str, symbol: str, logger: logging.Logger) -> list:
 def fetch_recent_klines(
     symbol: str,
     interval: str = "1",
-    total: int = 5280,
+    total: int = 10080,
 ) -> list:
     """Return ``total`` klines for ``symbol`` using backoff retry logic."""
     logger = get_debug_logger()

--- a/test.py
+++ b/test.py
@@ -41,15 +41,15 @@ def test_fetch_recent_klines_exact_count():
     """Test fetch returns the exact number of klines requested."""
     mock_klines = [
         [str(1717382400000 + i * 60000), "", "", "", "", "1"]
-        for i in range(5280)
+        for i in range(10080)
     ]
     mock_response = {"result": {"list": mock_klines}}
     with patch("core.requests.get") as mock_get:
         mock_get.return_value.status_code = 200
         mock_get.return_value.json.return_value = mock_response
-        result = core.fetch_recent_klines("BTCUSDT", total=5280)
+        result = core.fetch_recent_klines("BTCUSDT", total=10080)
         assert isinstance(result, list)
-        assert len(result) == 5280
+        assert len(result) == 10080
 
 
 
@@ -67,7 +67,7 @@ def test_fetch_recent_klines_insufficient():
         return MagicMock(status_code=200, json=lambda: {"result": {"list": []}})
 
     with patch("core.requests.get", side_effect=side_effect):
-        result = core.fetch_recent_klines("BTCUSDT", total=5280)
+        result = core.fetch_recent_klines("BTCUSDT", total=10080)
         assert result == []
 
 def test_clean_existing_excels(tmp_path):
@@ -91,7 +91,7 @@ def test_setup_logging():
 
 def test_process_symbol_with_mocked_logger():
     """Ensure process_symbol runs with valid klines and mocked logger."""
-    mock_klines = [[str(i), "", "", "", "", "2"] for i in range(5280)]
+    mock_klines = [[str(i), "", "", "", "", "2"] for i in range(10080)]
     with patch("core.fetch_recent_klines", return_value=mock_klines):
         result = core.process_symbol("BTCUSDT", MagicMock())
         assert isinstance(result, dict)
@@ -121,7 +121,7 @@ def test_calculate_price_correlation_perfect():
 
 def test_process_symbol_correlation_with_mocked_logger():
     """Ensure correlation processing returns expected keys."""
-    mock_klines = [[str(i), "", "", "", str(i), "2"] for i in range(5280)]
+    mock_klines = [[str(i), "", "", "", str(i), "2"] for i in range(10080)]
     with patch("core.fetch_recent_klines", return_value=mock_klines), \
          patch("core.get_open_interest_change", return_value=5.0):
         result = core.process_symbol_correlation("ETHUSDT", mock_klines, MagicMock())
@@ -350,7 +350,7 @@ def test_calculate_price_range_percent():
 
 def test_process_symbol_volatility_with_mocked_logger():
     """Ensure volatility metrics include expected keys."""
-    mock_klines = [[str(i), "1", "10", "8", "", "1"] for i in range(5280)]
+    mock_klines = [[str(i), "1", "10", "8", "", "1"] for i in range(10080)]
     with patch("core.fetch_recent_klines", return_value=mock_klines):
         result = core.process_symbol_volatility("BTCUSDT", MagicMock())
         expected = {
@@ -381,7 +381,7 @@ def test_calculate_price_change_percent():
 
 def test_process_symbol_price_change_with_mocked_logger():
     """Ensure price change metrics include expected keys."""
-    mock_klines = [[str(i), "", "", "", str(i), "1"] for i in range(5280)]
+    mock_klines = [[str(i), "", "", "", str(i), "1"] for i in range(10080)]
     with patch("core.fetch_recent_klines", return_value=mock_klines):
         result = core.process_symbol_price_change("BTCUSDT", MagicMock())
         expected_keys = {


### PR DESCRIPTION
## Summary
- fetch more kline history so the 4H percentile has enough samples
- update tests to match the new history length

## Testing
- `python run_checks.py`

------
https://chatgpt.com/codex/tasks/task_e_685d2b80a40c8321b6472d2491618c11