### PR TITLE
Add HTML navigation and dark theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,15 @@ market data and export `Crypto_Volume.xlsx`:
 python scan.py
 ```
 
+HTML versions of each table are written to the `html` folder in the project
+root. If the scanner is run on Windows, these pages are opened in Microsoft
+Edge automatically. The pages include a built-in refresh that updates them when
+new scans overwrite the files.
+Each page now uses a dark theme and includes buttons in the top-left corner for
+quickly switching between the different tables. Additional buttons labelled by
+timeframe let you sort the table values from largest to smallest or back again
+with repeated clicks.
+
 ## Grouping Debug Logs
 
 Use `group_logs.py` to organise `scanlog.txt` entries so that all lines for

--- a/continuous_scan.py
+++ b/continuous_scan.py
@@ -44,6 +44,16 @@ def run_periodic_scans(interval_minutes: int = 30) -> None:
                 logger,
                 filename=filename,
             )
+            scan.export_all_data_html(
+                volume_df,
+                funding_df,
+                oi_df,
+                corr_df,
+                vol_df,
+                price_df,
+                symbol_order,
+                logger,
+            )
             scan.send_push_notification(
                 "Scan complete",
                 f"{filename} has been exported.",


### PR DESCRIPTION
## Summary
- apply a dark theme to auto-refreshing HTML exports
- add navigation buttons to switch tables easily
- add timeframe sort buttons to HTML pages
- document the HTML dark theme feature

## Testing
- `pip install -r requirements.txt`
- `python run_checks.py`


------
https://chatgpt.com/codex/tasks/task_e_6868af85e7dc832186acdd2eaf3efc0c