### PR TITLE
Clarify price change independence

### DIFF
--- a/scan.py
+++ b/scan.py
@@ -473,6 +473,10 @@ def run_correlation_matrix_scan(
 def run_price_change_scan(all_symbols: list[tuple], logger: logging.Logger) -> pd.DataFrame:
     """Compute close price change for each symbol."""
     logger.info("Starting price change scan...")
+    # This scan only relies on price data and remains fully functional even
+    # when other scans such as the old volatility scan are disabled. It
+    # fetches klines for each symbol independently and does not use any
+    # results from other metrics.
     if not all_symbols:
         logger.warning("No symbols retrieved. Skipping price change export.")
         return pd.DataFrame()
@@ -487,6 +491,7 @@ def run_price_change_scan(all_symbols: list[tuple], logger: logging.Logger) -> p
         logger.warning("%d symbols failed: %s", len(failed), ", ".join(failed))
 
     df = pd.DataFrame(rows)
+    logger.info("Price change data collected for %d symbols", len(df))
     for col in [
         "5M Percentile",
         "15M Percentile",

--- a/test.py
+++ b/test.py
@@ -373,6 +373,18 @@ def test_process_symbol_price_change_with_mocked_logger():
         assert set(result.keys()) == expected_keys
 
 
+def test_run_price_change_scan_independent():
+    """Price change scan works without any volatility data."""
+    mock_klines = [[str(i), "", "", "", str(i), "1"] for i in range(10080)]
+    all_syms = [("BTCUSDT", 1), ("ETHUSDT", 2)]
+    logger = MagicMock()
+    with patch("core.fetch_recent_klines", return_value=mock_klines), \
+         patch("scan.export_to_html") as mock_export:
+        df = scan.run_price_change_scan(all_syms, logger)
+        assert set(df["Symbol"]) == {"BTCUSDT", "ETHUSDT"}
+        mock_export.assert_called_once()
+
+
 def test_percentile_rank_basic():
     """Percentile rank computes relative position of a value."""
     values = [1.0, 2.0, 3.0, 4.0]


### PR DESCRIPTION
## Summary
- document that price change scan works independently of the removed volatility scan
- log how many rows are gathered during the price change scan
- add a test proving the price change scan runs by itself

## Testing
- `python run_checks.py`

------
https://chatgpt.com/codex/tasks/task_e_6868d1f38f3883218293569b4019428a