### PR TITLE
Adjust correlation matrix refresh timing

### DIFF
--- a/continuous_scan.py
+++ b/continuous_scan.py
@@ -17,7 +17,7 @@ def run_periodic_scans() -> None:
         "volume": 9 * 60,
         "funding": 60,
         "oi": 60,
-        "corr": 3 * 60,
+        "corr": 30 * 60,
         "price": 21 * 60,
     }
     next_run = {key: 0 for key in intervals}

--- a/scan.py
+++ b/scan.py
@@ -615,7 +615,7 @@ def export_correlation_matrix_html(
     logger: logging.Logger,
     filename: str = "correlation_matrix.html",
     *,
-    refresh_seconds: int = 60,
+    refresh_seconds: int = 1800,
 ) -> None:
     """Write correlation matrices to a single HTML file with timeframe buttons."""
 
@@ -756,7 +756,7 @@ def main() -> None:
             logger,
         )
         export_correlation_matrices(matrix_map, logger)
-        export_correlation_matrix_html(matrix_map, logger, refresh_seconds=180)
+        export_correlation_matrix_html(matrix_map, logger, refresh_seconds=1800)
         send_push_notification(
             "Scan complete",
             "Scan.xlsx and Correlation_Matrix.xlsx have been exported.",


### PR DESCRIPTION
## Summary
- refresh correlation matrix HTML every 30 minutes
- update interval in continuous scan script

## Testing
- `python run_checks.py`

------
https://chatgpt.com/codex/tasks/task_e_6868e1f4e47483218e71e0b3beca99cd