### PR TITLE
Speed up scans with shared async kline cache

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 pandas
 requests
+httpx
 tqdm
 xlsxwriter
 pytest


### PR DESCRIPTION
## Summary
- add httpx dependency for async requests
- fetch all klines asynchronously and reuse them across scans
- parallelise correlation matrix generation
- update scan entry point to prefetch klines

## Testing
- `pip install -r requirements.txt`
- `python run_checks.py`

------
https://chatgpt.com/codex/tasks/task_e_6868eecc4220832189520734f5d46942