### PR TITLE
Reorder scan execution for efficiency

### DIFF
--- a/continuous_scan.py
+++ b/continuous_scan.py
@@ -17,10 +17,10 @@ def run_periodic_scans() -> None:
     filename = f"Scan_{timestamp}.xlsx"
 
     intervals = {
-        "volume": 9 * 60,
         "funding": 60,
         "oi": 60,
         "corr": 3 * 60,
+        "volume": 9 * 60,
         "price": 21 * 60,
     }
     next_run = {key: 0 for key in intervals}
@@ -36,9 +36,10 @@ def run_periodic_scans() -> None:
         now = time.time()
         try:
             if (
-                now >= next_run["volume"]
-                or now >= next_run["funding"]
+                now >= next_run["funding"]
                 or now >= next_run["oi"]
+                or now >= next_run["corr"]
+                or now >= next_run["volume"]
             ):
                 logger.info("Fetching USDT perpetual futures from Bybit...")
                 all_symbols = core.get_tradeable_symbols_sorted_by_volume()
@@ -47,7 +48,29 @@ def run_periodic_scans() -> None:
                 if not all_symbols:
                     logger.warning("No symbols retrieved. Skipping export.")
                 else:
-                    volume_df, funding_df, oi_df, symbol_order = scan.run_scan(all_symbols, logger)
+                    if now >= next_run["funding"]:
+                        funding_df = scan.run_funding_rate_scan(all_symbols, logger)
+                        symbol_order = [s for s, _ in all_symbols]
+                        next_run["funding"] = now + intervals["funding"]
+
+                    if now >= next_run["oi"]:
+                        oi_df = scan.run_open_interest_scan(all_symbols, logger)
+                        next_run["oi"] = now + intervals["oi"]
+
+                    if now >= next_run["corr"]:
+                        matrix_map = scan.run_correlation_matrix_scan(all_symbols, logger)
+                        scan.export_correlation_matrices(matrix_map, logger)
+                        scan.send_push_notification(
+                            "Correlation matrix complete",
+                            "Correlation_Matrix.xlsx has been exported.",
+                            logger,
+                        )
+                        next_run["corr"] = now + intervals["corr"]
+
+                    if now >= next_run["volume"]:
+                        volume_df = scan.run_volume_scan(all_symbols, logger)
+                        next_run["volume"] = now + intervals["volume"]
+
                     if not price_df.empty:
                         scan.export_all_data(
                             volume_df,
@@ -63,24 +86,6 @@ def run_periodic_scans() -> None:
                             f"{filename} has been exported.",
                             logger,
                         )
-                    if now >= next_run["volume"]:
-                        next_run["volume"] = now + intervals["volume"]
-                    if now >= next_run["funding"]:
-                        next_run["funding"] = now + intervals["funding"]
-                    if now >= next_run["oi"]:
-                        next_run["oi"] = now + intervals["oi"]
-
-            if now >= next_run["corr"]:
-                logger.info("Updating correlation matrix")
-                all_symbols = core.get_tradeable_symbols_sorted_by_volume()
-                matrix_map = scan.run_correlation_matrix_scan(all_symbols, logger)
-                scan.export_correlation_matrices(matrix_map, logger)
-                scan.send_push_notification(
-                    "Correlation matrix complete",
-                    "Correlation_Matrix.xlsx has been exported.",
-                    logger,
-                )
-                next_run["corr"] = now + intervals["corr"]
 
             if now >= next_run["price"]:
                 logger.info("Updating price change data")

--- a/scan.py
+++ b/scan.py
@@ -378,27 +378,77 @@ def scan_and_collect_results(symbols: list[str],
     return rows, failed
 
 
-def run_scan(
+def run_funding_rate_scan(
+    all_symbols: list[tuple],
+    logger: logging.Logger,
+) -> pd.DataFrame:
+    """Collect the latest funding rate for each symbol."""
+
+    logger.info("Scanning funding rates...")
+    rows, _ = scan_and_collect_results(
+        [s for s, _ in all_symbols],
+        logger,
+        core.process_symbol_funding,
+    )
+    df = pd.DataFrame(rows)
+    export_to_html(
+        df,
+        [s for s, _ in all_symbols],
+        logger,
+        filename="funding_rates.html",
+        header="Latest Funding Rates",
+        refresh_seconds=60,
+        include_sort_buttons=True,
+    )
+    return df
+
+
+def run_open_interest_scan(
+    all_symbols: list[tuple],
+    logger: logging.Logger,
+) -> pd.DataFrame:
+    """Collect open interest change metrics for each symbol."""
+
+    logger.info("Scanning open interest changes...")
+    rows, _ = scan_and_collect_results(
+        [s for s, _ in all_symbols],
+        logger,
+        core.process_symbol_open_interest,
+    )
+    df = pd.DataFrame(rows)
+    export_to_html(
+        df,
+        [s for s, _ in all_symbols],
+        logger,
+        filename="open_interest.html",
+        header="% Change in Open Interest",
+        refresh_seconds=60,
+        include_sort_buttons=True,
+    )
+    return df
+
+
+def run_volume_scan(
     all_symbols: list[tuple],
     logger: logging.Logger,
     klines_cache: dict | None = None,
-) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame, list[str]]:
-    """Fetch volume, funding and open interest metrics."""
+) -> pd.DataFrame:
+    """Collect volume metrics for each symbol."""
 
     logger.info("Scanning volume metrics...")
 
-    volume_rows, failed = scan_and_collect_results(
+    rows, failed = scan_and_collect_results(
         [s for s, _ in all_symbols],
         logger,
         lambda s, log: core.process_symbol(s, log, klines_cache),
     )
 
     volume_map = dict(all_symbols)
-    for row in volume_rows:
+    for row in rows:
         row["24h USD Volume"] = volume_map.get(row["Symbol"], 0)
-    volume_df = pd.DataFrame(volume_rows)
+    df = pd.DataFrame(rows)
     export_to_html(
-        volume_df,
+        df,
         [s for s, _ in all_symbols],
         logger,
         filename="volume.html",
@@ -407,42 +457,22 @@ def run_scan(
         include_sort_buttons=True,
     )
 
-    logger.info("Scanning funding rates...")
-    funding_rows, _ = scan_and_collect_results(
-        [s for s, _ in all_symbols],
-        logger,
-        core.process_symbol_funding,
-    )
-    funding_df = pd.DataFrame(funding_rows)
-    export_to_html(
-        funding_df,
-        [s for s, _ in all_symbols],
-        logger,
-        filename="funding_rates.html",
-        header="Latest Funding Rates",
-        refresh_seconds=60,
-        include_sort_buttons=True,
-    )
-
-    logger.info("Scanning open interest changes...")
-    oi_rows, _ = scan_and_collect_results(
-        [s for s, _ in all_symbols],
-        logger,
-        core.process_symbol_open_interest,
-    )
-    oi_df = pd.DataFrame(oi_rows)
-    export_to_html(
-        oi_df,
-        [s for s, _ in all_symbols],
-        logger,
-        filename="open_interest.html",
-        header="% Change in Open Interest",
-        refresh_seconds=60,
-        include_sort_buttons=True,
-    )
-
     if failed:
         logger.warning("%d symbols failed: %s", len(failed), ", ".join(failed))
+
+    return df
+
+
+def run_scan(
+    all_symbols: list[tuple],
+    logger: logging.Logger,
+    klines_cache: dict | None = None,
+) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame, list[str]]:
+    """Fetch funding, open interest and volume metrics in sequence."""
+
+    funding_df = run_funding_rate_scan(all_symbols, logger)
+    oi_df = run_open_interest_scan(all_symbols, logger)
+    volume_df = run_volume_scan(all_symbols, logger, klines_cache)
 
     return (
         volume_df,
@@ -841,8 +871,11 @@ def main() -> None:
         logger.info("Fetching klines asynchronously for %d symbols", len(symbols_only))
         klines_cache = asyncio.run(core.fetch_all_recent_klines_async(symbols_only))
 
-        volume_df, funding_df, oi_df, symbol_order = run_scan(all_symbols, logger, klines_cache)
+        funding_df = run_funding_rate_scan(all_symbols, logger)
+        oi_df = run_open_interest_scan(all_symbols, logger)
         matrix_map = run_correlation_matrix_scan(all_symbols, logger, klines_cache)
+        volume_df = run_volume_scan(all_symbols, logger, klines_cache)
+        symbol_order = [s for s, _ in all_symbols]
         price_df = run_price_change_scan(all_symbols, logger, klines_cache)
 
         export_correlation_matrices(matrix_map, logger)


### PR DESCRIPTION
## Summary
- scan funding rates, open interest and volume via dedicated functions
- change main order to run fast metrics first
- update continuous scanning loop to match new sequence

## Testing
- `pip install -r requirements.txt`
- `python run_checks.py`

------
https://chatgpt.com/codex/tasks/task_e_686912a79b688321b0ec46a13a7a94cd