### PR TITLE
Auto-open correlation HTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Results are written to multiple spreadsheets:
 * ``Funding_Rates.xlsx`` with the latest funding rate for each pair
 * ``Open_Interest.xlsx`` showing percent changes in open interest across several timeframes, now including 1 day, 1 week and 1 month intervals
 * ``Price_Change.xlsx`` listing the percentage price change over common intraday periods
+* ``Correlation.xlsx`` summarising how closely each pair moves with BTCUSDT
 
 The funding and open interest sheets omit the ``24h USD Volume`` column, but rows remain sorted using this metric.
 
@@ -42,6 +43,7 @@ HTML versions of each table are written to the `html` folder in the project
 root. If the scanner is run on Windows, these pages are opened in Microsoft
 Edge automatically. Each page opens only once per session and includes a
 built-in refresh that updates it when new scans overwrite the file.
+The correlation table launches in Edge as soon as its Excel file is written.
 Each page now uses a dark theme and includes buttons in the top-left corner for
 quickly switching between the different tables. All buttons sit in a single
 horizontal row aligned to the far left. They let you sort by any timeframe

--- a/continuous_scan.py
+++ b/continuous_scan.py
@@ -97,11 +97,8 @@ def run_periodic_scans() -> None:
                 logger.info("Updating correlation matrix")
                 all_symbols = core.get_tradeable_symbols_sorted_by_volume()
                 corr_df = scan.run_correlation_matrix_scan(all_symbols, logger)
-                scan.export_correlation_matrices(corr_df, logger)
-                scan.export_correlation_matrix_html(
-                    corr_df,
-                    logger,
-                    refresh_seconds=intervals["corr"],
+                scan.export_correlation_matrices(
+                    corr_df, logger
                 )
                 scan.send_push_notification(
                     "Correlation scan complete",

--- a/scan.py
+++ b/scan.py
@@ -631,6 +631,7 @@ def export_correlation_matrices(
         header="% Correlation to BTCUSDT",
         sheet_name="Correlation",
     )
+    export_correlation_matrix_html(df, logger)
 
 
 def export_correlation_matrix_html(
@@ -725,7 +726,6 @@ def main() -> None:
         price_df = run_price_change_scan(all_symbols, logger, klines_cache)
 
         export_correlation_matrices(corr_df, logger)
-        export_correlation_matrix_html(corr_df, logger)
         send_push_notification(
             "Correlation scan complete",
             "Correlation.xlsx has been exported.",

--- a/test.py
+++ b/test.py
@@ -404,6 +404,18 @@ def test_export_correlation_matrix_html():
         mock_export.assert_called_once()
 
 
+def test_export_correlation_matrices_opens_html():
+    """Excel export also triggers HTML export."""
+    df = pd.DataFrame({"Symbol": ["BTCUSDT"], "5M": [0]})
+    logger = MagicMock()
+    with patch("scan.export_to_excel") as mock_excel, patch(
+        "scan.export_correlation_matrix_html"
+    ) as mock_html:
+        scan.export_correlation_matrices(df, logger)
+        mock_excel.assert_called_once()
+        mock_html.assert_called_once_with(df, logger)
+
+
 def test_percentile_rank_basic():
     """Percentile rank computes relative position of a value."""
     values = [1.0, 2.0, 3.0, 4.0]


### PR DESCRIPTION
## Summary
- export correlation HTML when saving Excel
- open `correlation.html` automatically on scan completion
- document the new behaviour
- cover the HTML export call in tests

## Testing
- `pytest -q test.py`

------
https://chatgpt.com/codex/tasks/task_e_686919baaf9483218fcf4661686e81b6